### PR TITLE
Fix application id check in instrumentation test

### DIFF
--- a/app/src/androidTest/java/com/harshitaapptech/randomquote/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/harshitaapptech/randomquote/ExampleInstrumentedTest.kt
@@ -2,6 +2,7 @@ package com.harshitaapptech.randomquote
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.harshitaapptech.randomquote.BuildConfig
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,6 +20,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.aws.randomquote", appContext.packageName)
+        assertEquals(BuildConfig.APPLICATION_ID, appContext.packageName)
     }
 }


### PR DESCRIPTION
## Summary
- update instrumented test to verify application id with BuildConfig

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68418212cdc48328a7ec37008cf1c04e